### PR TITLE
Fix urlretrieve import for Python 3

### DIFF
--- a/puzzlemaker/fishnet.py
+++ b/puzzlemaker/fishnet.py
@@ -13,6 +13,7 @@ import ctypes
 
 import http.client as httplib
 import urllib.parse as urlparse
+import urllib.request as urlrequest
 import urllib
 
 
@@ -85,7 +86,7 @@ def update_stockfish(filename):
                                  round(min(a * b, c) * 100 / c)))
             sys.stderr.flush()
 
-    urllib.urlretrieve(asset["browser_download_url"], filename, reporthook)
+    urlrequest.urlretrieve(asset["browser_download_url"], filename, reporthook)
 
     sys.stderr.write("\n")
     sys.stderr.flush()

--- a/puzzlemaker/fishnet.py
+++ b/puzzlemaker/fishnet.py
@@ -14,7 +14,6 @@ import ctypes
 import http.client as httplib
 import urllib.parse as urlparse
 import urllib.request as urlrequest
-import urllib
 
 
 def stockfish_command(update=False):


### PR DESCRIPTION
Fix `AttributeError: 'module' object has no attribute 'urlretrieve'` on Python 3, by importing urllib.request
(ref: https://stackoverflow.com/questions/17960942/attributeerror-module-object-has-no-attribute-urlretrieve)