### PR TITLE
Fix instances where code tries to evaluate None moves

### DIFF
--- a/puzzlemaker/analysis.py
+++ b/puzzlemaker/analysis.py
@@ -41,11 +41,10 @@ class AnalysisEngine(object):
     @staticmethod
     def best_move(board, depth) -> AnalyzedMove:
         info = AnalysisEngine._analyze(board, depth)
-        if info.get("pv"):
-            best_move = info["pv"][0]
-        else:
-            best_move = None
         score = info["score"].white()
+        if not info.get("pv"):
+            return AnalyzedMove(None, None, score)
+        best_move = info["pv"][0]
         return AnalyzedMove(best_move, board.san(best_move), score)
 
     @staticmethod

--- a/puzzlemaker/puzzle_position.py
+++ b/puzzlemaker/puzzle_position.py
@@ -30,8 +30,12 @@ class PuzzlePosition(object):
         self.candidate_moves: List[AnalyzedMove] = []
 
     def _log_position(self):
-        move_san = self.initial_board.san(self.initial_move)
-        log(Color.VIOLET, "\nAfter %s %s" % (fullmove_string(self.initial_board).strip(), move_san))
+        if self.initial_move:
+            move_san = self.initial_board.san(self.initial_move)
+            log(
+                Color.VIOLET,
+                "\nAfter %s %s" % (fullmove_string(self.initial_board).strip(), move_san)
+            )
         log_board(self.board)
         log(Color.DARK_BLUE, "Material difference:  %d" % material_difference(self.board))
         log(Color.DARK_BLUE, "# legal moves:        %d" % self._num_legal_moves())


### PR DESCRIPTION
I was testing the program with this PGN file ([Philidor.zip](https://github.com/linrock/chess-puzzle-maker/files/5413154/Philidor.zip)) with the command `./make_puzzles.py --threads 8 --scan-depth 10 --search-depth 10 --pgn Philidor.pgn` when I got the following traceback:

```
Traceback (most recent call last):
  File "./make_puzzles.py", line 127, in <module>
    puzzle.generate(settings.search_depth)
  File "/home/user/repos/chess-puzzle-maker/puzzlemaker/puzzle.py", line 149, in generate
    self._calculate_final_score(depth)
  File "/home/user/repos/chess-puzzle-maker/puzzlemaker/puzzle.py", line 113, in _calculate_final_score
    self.final_score = AnalysisEngine.score(self.positions[-1].board, depth)
  File "/home/user/repos/chess-puzzle-maker/puzzlemaker/analysis.py", line 70, in score
    return AnalysisEngine.best_move(board, depth).score
  File "/home/user/repos/chess-puzzle-maker/puzzlemaker/analysis.py", line 49, in best_move
    return AnalyzedMove(best_move, board.san(best_move), score)
  File "/home/user/.local/lib/python3.8/site-packages/chess/__init__.py", line 2655, in san
    return self._algebraic(move)
  File "/home/user/.local/lib/python3.8/site-packages/chess/__init__.py", line 2668, in _algebraic
    san = self._algebraic_and_push(move, long=long)
  File "/home/user/.local/lib/python3.8/site-packages/chess/__init__.py", line 2676, in _algebraic_and_push
    self.push(move)
  File "/home/user/.local/lib/python3.8/site-packages/chess/__init__.py", line 2015, in push
    move = self._to_chess960(move)
  File "/home/user/.local/lib/python3.8/site-packages/chess/__init__.py", line 3413, in _to_chess960
    if move.from_square == E1 and self.kings & BB_E1:
AttributeError: 'NoneType' object has no attribute 'from_square'
```
I noticed that this happened when the code tried to get the SAN for an engine move that didn't exist, since the position evaluated was a checkmate. You can replicate the error by calling `chess.Board().push_san(None)`. I shifted the lines around so that we only try to get a SAN move if the engine move does exist.

After I was done with that, I decided to run `inv test` and found that `test_game_over_position` threw an error for a similar reason, so this PR should fix that as well.

This change causes the test suite go from 2 failures and 3 errors to one failure, `test_puzzles_without_initial_move` was expecting the puzzle to end with a material advantage, but I checked the initial FEN (`r2qr3/2pp1pkp/b1p3p1/p7/P7/1PnBPQ2/2PN1PPP/R4RK1 w - - 0 1`) and the final (`4r3/2pp1pkp/r3q1p1/p1p1P3/P7/1PnQ4/2PN1PPP/R4RK1 w - - 1 5`) and both sides seem to have the same number of pieces. I'm assuming the problem is that the puzzle needs an extra move to end. I'll try to fix this as well.