### PR TITLE
Remove contempt setting

### DIFF
--- a/make_puzzles.py
+++ b/make_puzzles.py
@@ -71,7 +71,6 @@ engine = AnalysisEngine.instance()
 engine.configure({
   'Threads': settings.threads,
   'Hash': settings.memory,
-  'Contempt': 0,
 })
 
 if settings.quiet:


### PR DESCRIPTION
Stockfish removed the contempt setting in 2021: https://github.com/official-stockfish/Stockfish/commit/6146cfed6d201f510562f590cbfaa8b5cfd35785 This line will cause an error for anyone with a new version of Stockfish.